### PR TITLE
Add drink images to vending buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,11 +7,22 @@ def main() -> None:
     root = tk.Tk()
     machine = Machine(root)
 
+    # Define available drinks with associated images
+    drink_infos = [
+        ("사이다", 600, "src/drinks/cider.png"),
+        ("콜라", 700, "src/drinks/coke.png"),
+        ("환타", 700, "src/drinks/fanta.png"),
+        ("이온음료", 800, "src/drinks/ion.png"),
+        ("에이드", 800, "src/drinks/ade.png"),
+        ("소다", 650, "src/drinks/soda.png"),
+        ("생수", 500, "src/drinks/water.png"),
+    ]
+
+    # Fill the vending machine with drinks. Images will be displayed on buttons.
     for i in range(24):
-        image = "src/drinks/water.png"
-        machine.controller.add_drinks(
-            Drink("물", 500, 0 if i % 2 == 0 else 5, image)
-        )
+        name, price, image = drink_infos[i % len(drink_infos)]
+        count = 0 if i % 2 == 0 else 5
+        machine.controller.add_drinks(Drink(name, price, count, image))
         
     machine.refresh_gui()
     root.mainloop()

--- a/package/machine.py
+++ b/package/machine.py
@@ -79,7 +79,10 @@ class Machine:
 
         tk.Button(right_frame, text="카드 투입", bg="green", fg="white", command=self.use_card).pack()
 
-        admin_btn = tk.Button(right_frame, text="🔑", command=self.admin_menu, bg="white")
+        # Use a keyhole image for the admin button
+        admin_img = self.load_image("src/drinks/keyhole.png")
+        admin_btn = tk.Button(right_frame, image=admin_img, command=self.admin_menu, bg="white")
+        self.images.append(admin_img)
         admin_btn.place(relx=0.95, rely=0.95, anchor="se")
 
     def refresh_gui(self) -> None:


### PR DESCRIPTION
## Summary
- assign unique drink images for each vending button
- show an icon for admin button using the keyhole image

## Testing
- `python -m py_compile package/*.py main.py`
- `python main.py` *(fails: no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68418c90327c83249ab896ef9dad4564